### PR TITLE
Java version inferring by AEM jar

### DIFF
--- a/src/main/kotlin/com/cognifide/gradle/aem/AemExtension.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/AemExtension.kt
@@ -26,7 +26,6 @@ import com.cognifide.gradle.aem.common.utils.WebBrowser
 import com.cognifide.gradle.aem.pkg.PackageSyncPlugin
 import com.cognifide.gradle.common.CommonExtension
 import com.cognifide.gradle.common.common
-import com.cognifide.gradle.common.pluginProject
 import com.cognifide.gradle.common.pluginProjects
 import com.cognifide.gradle.common.utils.Patterns
 import com.cognifide.gradle.common.utils.using

--- a/src/main/kotlin/com/cognifide/gradle/aem/AemExtension.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/AemExtension.kt
@@ -26,6 +26,7 @@ import com.cognifide.gradle.aem.common.utils.WebBrowser
 import com.cognifide.gradle.aem.pkg.PackageSyncPlugin
 import com.cognifide.gradle.common.CommonExtension
 import com.cognifide.gradle.common.common
+import com.cognifide.gradle.common.pluginProject
 import com.cognifide.gradle.common.pluginProjects
 import com.cognifide.gradle.common.utils.Patterns
 import com.cognifide.gradle.common.utils.using

--- a/src/main/kotlin/com/cognifide/gradle/aem/AemVersion.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/AemVersion.kt
@@ -96,12 +96,13 @@ class AemVersion(val value: String) : Comparable<AemVersion> {
             return UnclosedRange(start, end)
         }
 
-        fun fromJar(jar: File) = jar.let { ZipFile(it).listDir("static/app") }
-            .map { it.substringAfterLast("/") }
-            .firstOrNull { it.startsWith("cq-quickstart-") && it.endsWith(".jar") }
-            ?.let { AemVersion.fromJarFileName(it) }
+        fun fromJar(jar: File): AemVersion? = jar.takeIf { it.exists() }
+            ?.let { ZipFile(it).listDir("static/app") }
+            ?.map { it.substringAfterLast("/") }
+            ?.firstOrNull { it.startsWith("cq-quickstart-") && it.endsWith(".jar") }
+            ?.let { fromJarFileName(it) }
 
-        fun fromJarFileName(fileName: String) = fileName
+        fun fromJarFileName(fileName: String): AemVersion = fileName
             .removePrefix("cq-quickstart-").removePrefix("cloudready-")
             .substringBefore("-").let { AemVersion(it) }
     }

--- a/src/main/kotlin/com/cognifide/gradle/aem/AemVersion.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/AemVersion.kt
@@ -2,7 +2,9 @@ package com.cognifide.gradle.aem
 
 import com.cognifide.gradle.common.utils.Formats
 import com.cognifide.gradle.common.utils.Patterns
+import com.cognifide.gradle.common.zip.ZipFile
 import org.gradle.api.JavaVersion
+import java.io.File
 
 class AemVersion(val value: String) : Comparable<AemVersion> {
 
@@ -19,6 +21,14 @@ class AemVersion(val value: String) : Comparable<AemVersion> {
     fun atMost(other: String) = atMost(AemVersion(other))
 
     fun inRange(range: String): Boolean = range.contains("-") && this in unclosedRange(range, "-")
+
+    fun inRangeOrMatches(valueOrPattern: String) = inRange(valueOrPattern) || Patterns.wildcard(value, valueOrPattern)
+
+    fun javaCompatibleVersions(compatibility: Map<String, String>): List<JavaVersion> {
+        return compatibility.entries.mapNotNull { (aemVersionValue, javaVersionList) ->
+            if (inRangeOrMatches(aemVersionValue)) javaVersionList.javaVersions("|") else null
+        }.firstOrNull() ?: listOf()
+    }
 
     /**
      * Indicates repository restructure performed in AEM 6.4.0 / preparations for making AEM available on cloud.
@@ -85,6 +95,15 @@ class AemVersion(val value: String) : Comparable<AemVersion> {
             val (start, end) = versions.map { AemVersion(it) }
             return UnclosedRange(start, end)
         }
+
+        fun fromJar(jar: File) = jar.let { ZipFile(it).listDir("static/app") }
+            .map { it.substringAfterLast("/") }
+            .firstOrNull { it.startsWith("cq-quickstart-") && it.endsWith(".jar") }
+            ?.let { AemVersion.fromJarFileName(it) }
+
+        fun fromJarFileName(fileName: String) = fileName
+            .removePrefix("cq-quickstart-").removePrefix("cloudready-")
+            .substringBefore("-").let { AemVersion(it) }
     }
 }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstance.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstance.kt
@@ -9,7 +9,6 @@ import com.cognifide.gradle.aem.common.instance.local.Status
 import com.cognifide.gradle.aem.common.instance.oak.OakRun
 import com.cognifide.gradle.aem.common.instance.service.osgi.Bundle
 import com.cognifide.gradle.common.utils.Formats
-import com.cognifide.gradle.common.zip.ZipFile
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import org.apache.commons.io.FileUtils
@@ -140,17 +139,9 @@ class LocalInstance(aem: AemExtension) : Instance(aem) {
 
     private fun readVersionFromJar() = readVersionFromExtractedJar() ?: readVersionFromQuickstartJar() ?: AemVersion.UNKNOWN
 
-    private fun readVersionFromExtractedJar() = jar?.name?.let { readVersionFromJarFileName(it) }
+    private fun readVersionFromExtractedJar() = jar?.name?.let { AemVersion.fromJarFileName(it) }
 
-    private fun readVersionFromQuickstartJar() = quickstartJar
-            .let { ZipFile(it).listDir("static/app") }
-            .map { it.substringAfterLast("/") }
-            .firstOrNull { it.startsWith("cq-quickstart-") && it.endsWith(".jar") }
-            ?.let { readVersionFromJarFileName(it) }
-
-    private fun readVersionFromJarFileName(fileName: String) = fileName
-            .removePrefix("cq-quickstart-").removePrefix("cloudready-")
-            .substringBefore("-").let { AemVersion(it) }
+    private fun readVersionFromQuickstartJar() = AemVersion.fromJar(quickstartJar)
 
     private val startScript: Script get() = script("start")
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstanceManager.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/LocalInstanceManager.kt
@@ -630,7 +630,7 @@ class LocalInstanceManager(internal val aem: AemExtension) : Serializable {
     }
 
     fun determineJavaCompatibleVersions(): List<JavaVersion> {
-        val aemVersion = quickstart.jar?.takeIf { it.exists() }?.let { AemVersion.fromJar(it) } ?: return listOf()
+        val aemVersion = quickstart.jar?.let { AemVersion.fromJar(it) } ?: return listOf()
         return aemVersion.javaCompatibleVersions(javaCompatibility.get())
     }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/instance/LocalInstancePlugin.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/instance/LocalInstancePlugin.kt
@@ -6,9 +6,7 @@ import com.cognifide.gradle.aem.instance.tasks.InstanceRcp
 import com.cognifide.gradle.aem.instance.tasks.InstanceTail
 import com.cognifide.gradle.aem.instance.tasks.*
 import com.cognifide.gradle.aem.pkg.PackagePlugin
-import com.cognifide.gradle.common.CommonDefaultPlugin
-import com.cognifide.gradle.common.RuntimePlugin
-import com.cognifide.gradle.common.checkForce
+import com.cognifide.gradle.common.*
 import com.cognifide.gradle.common.tasks.runtime.*
 import org.gradle.api.Project
 


### PR DESCRIPTION
if plugin `com.cognifife.aem.instance.local` is applied and Quickstart JAR set, then GAP will automatically assign to all projects applying `com.cognifide.aem.common` recent compatible version of Java to be used in:

*   launching AEM
*   compiling Java / making OSGi bundles
*   launching Maven in hybrid builds

As an effect, property

```
javaSupport.version=11 
```

will be no longer needed as GAP will automatically infer the best compatible Java version for AEM.