### PR TITLE
Update README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -437,6 +437,14 @@ subprojects {
 }
 ```
 
+### Target individual instances when running tasks
+
+The ability to perform tasks against individual instances is provided by the Common Plugin, which comes with instance filtering. [Read more on instance filtering](https://github.com/wttech/gradle-aem-plugin/blob/master/docs/common-plugin.md#instance-filtering) if you're looking for information on:
+  - how to destroy an individual instance,
+  - how to start or stop author/publish instances only,
+  - how to deploy to a single instance,
+  - etc.
+
 ## Building
 
 1. Clone this project using command `git clone https://github.com/wttech/gradle-aem-plugin.git`


### PR DESCRIPTION
Provided a short how-to section on targeting individual instances, which points to the area of the documentation where it's described in detail. Last week, I was trying to find this information but couldn't find it in the README. It wasn't obvious to me that the _Common plugin_ was responsible for this, rather than, say, the _Instance plugin_.

I've added a few bullet points matching the kind of phrases I was searching for.