### PR TITLE
Maven build performance improvement

### DIFF
--- a/src/main/kotlin/com/cognifide/gradle/aem/common/mvn/DependencyGraph.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/mvn/DependencyGraph.kt
@@ -74,6 +74,7 @@ class DependencyGraph(val build: MvnBuild) {
     }
 
     val dotDependencies = aem.obj.list<Dependency> {
+        finalizeValueOnRead()
         set(aem.obj.provider {
             generateDotFile().lineSequence().mapNotNull { line ->
                 line.takeIf { it.contains(" -> ") }?.trim()?.split(" -> ")?.let {
@@ -88,6 +89,7 @@ class DependencyGraph(val build: MvnBuild) {
     }
 
     val dotArtifacts = aem.obj.list<Artifact> {
+        finalizeValueOnRead()
         set(aem.obj.provider {
             generateDotFile().lineSequence().mapNotNull { line ->
                 line.takeIf { it.contains("[label=") }?.trim()?.substringBefore("[label=")?.removeSurrounding("\"")

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/mvn/MvnBuild.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/mvn/MvnBuild.kt
@@ -208,12 +208,15 @@ class MvnBuild(val aem: AemExtension) {
         }
     }
 
-    fun defineModuleTaskDependenciesFromGraph() = depGraph.all.get().forEach { dependency ->
-        val module1 = moduleResolver.findByArtifact(dependency.from)
-        val module2 = moduleResolver.findByArtifact(dependency.to)
+    fun defineModuleTaskDependenciesFromGraph() {
+        val artifactModuleLookupCache = mutableMapOf<Artifact, ModuleDescriptor?>()
+        depGraph.all.get().forEach { dependency ->
+            val module1 = artifactModuleLookupCache.getOrPut(dependency.from) { moduleResolver.findByArtifact(dependency.from) }
+            val module2 = artifactModuleLookupCache.getOrPut(dependency.to) { moduleResolver.findByArtifact(dependency.to) }
 
-        if (module1 != null && module2 != null) {
-            defineModuleTaskDependenciesFromGraph(dependency, module1, module2)
+            if (module1 != null && module2 != null) {
+                defineModuleTaskDependenciesFromGraph(dependency, module1, module2)
+            }
         }
     }
 


### PR DESCRIPTION
For more complex Maven modules structure, calculating dependencies between modules could be slow.
By introducing lookup cache, I reduced configuration phase time by about 8 seconds so that it behaves almost instant.