### PR TITLE
Remove AEP from launcher

### DIFF
--- a/launcher/src/main/kotlin/com/cognifide/gradle/aem/launcher/BuildScaffolder.kt
+++ b/launcher/src/main/kotlin/com/cognifide/gradle/aem/launcher/BuildScaffolder.kt
@@ -10,7 +10,6 @@ class BuildScaffolder(private val launcher: Launcher) {
         saveSettings()
         saveRootBuildScript()
         saveEnvBuildScript()
-        saveEnvSrcFiles()
     }
 
     private fun saveBuildSrc() = launcher.workFileOnce("buildSrc/build.gradle.kts") {
@@ -24,7 +23,6 @@ class BuildScaffolder(private val launcher: Launcher) {
             
             dependencies {
                 implementation("com.cognifide.gradle:aem-plugin:${launcher.pluginVersion}")
-                implementation("com.cognifide.gradle:environment-plugin:2.1.4")
                 implementation("com.cognifide.gradle:common-plugin:1.0.41")
                 implementation("com.neva.gradle:fork-plugin:7.0.5")
             }
@@ -95,13 +93,10 @@ class BuildScaffolder(private val launcher: Launcher) {
         writeText("""
             plugins {
                 id("com.cognifide.aem.instance.local")
-                id("com.cognifide.environment")
             }
             
             val instancePassword = common.prop.string("instance.default.password")
             val publishHttpUrl = common.prop.string("publish.httpUrl") ?: aem.findInstance("local-publish")?.httpUrl ?: "http://127.0.0.1:4503"
-            val dispatcherHttpUrl = common.prop.string("dispatcher.httpUrl") ?: "http://127.0.0.1:80"
-            val dispatcherTarUrl = common.prop.string("dispatcher.tarUrl") ?: "http://download.macromedia.com/dispatcher/download/dispatcher-apache2.4-linux-x86_64-4.3.3.tar.gz"
             val servicePackUrl = common.prop.string("localInstance.spUrl")
             val coreComponentsUrl = common.prop.string("localInstance.coreComponentsUrl")
 
@@ -115,72 +110,6 @@ class BuildScaffolder(private val launcher: Launcher) {
                             agent { configure(transportUri = "${'$'}publishHttpUrl/bin/receive?sling:authRequestLogin=1", transportUser = "admin", transportPassword = instancePassword, userId = "admin") }
                             version.set(publishHttpUrl)
                         }
-                        configureReplicationAgentPublish("flush") {
-                            agent { configure(transportUri = "${'$'}dispatcherHttpUrl/dispatcher/invalidate.cache") }
-                            version.set(dispatcherHttpUrl)
-                        }
-                    }
-                }
-            }
-            
-            environment { // https://github.com/Cognifide/gradle-environment-plugin
-                docker {
-                    containers {
-                        "httpd" {
-                            resolve {
-                                resolveFiles {
-                                    download(dispatcherTarUrl).use {
-                                        copyArchiveFile(it, "**/dispatcher-apache*.so", file("modules/mod_dispatcher.so"))
-                                    }
-                                }
-                                ensureDir("htdocs", "cache", "logs")
-                            }
-                            up {
-                                symlink(
-                                    "/etc/httpd.extra/conf.modules.d/02-dispatcher.conf" to "/etc/httpd/conf.modules.d/02-dispatcher.conf",
-                                    "/etc/httpd.extra/conf.d/variables/default.vars" to "/etc/httpd/conf.d/variables/default.vars"
-                                )
-                                ensureDir("/usr/local/apache2/logs", "/var/www/localhost/htdocs", "/var/www/localhost/cache")
-                                execShell("Starting HTTPD server", "/usr/sbin/httpd -k start")
-                            }
-                            reload {
-                                cleanDir("/var/www/localhost/cache")
-                                execShell("Restarting HTTPD server", "/usr/sbin/httpd -k restart")
-                            }
-                            dev {
-                                watchRootDir(
-                                    "dispatcher/src/conf.d",
-                                    "dispatcher/src/conf.dispatcher.d",
-                                    "env/src/environment/httpd")
-                            }
-                        }
-                    }
-                }
-                hosts {
-                    "http://publish" { tag("publish") }
-                    "http://dispatcher" { tag("dispatcher") }
-                }
-                healthChecks {
-                    aem.findInstance("local-author")?.let { instance ->
-                        http("Author Sites Editor", "${'$'}{instance.httpUrl}/sites.html") {
-                            containsText("Sites")
-                            options { basicCredentials = instance.credentials }
-                        }
-                        http("Author Replication Agent - Publish", "${'$'}{instance.httpUrl}/etc/replication/agents.author/publish.test.html") {
-                            containsText("succeeded")
-                            options { basicCredentials = instance.credentials }
-                        }
-                    }
-                    aem.findInstance("local-publish")?.let { instance ->
-                        http("Publish Replication Agent - Flush", "${'$'}{instance.httpUrl}/etc/replication/agents.publish/flush.test.html") {
-                            containsText("succeeded")
-                            options { basicCredentials = instance.credentials }
-                        }
-                        /*
-                        http("Site Home", "http://publish/us/en.html") {
-                            containsText("My Site")
-                        }
-                        */
                     }
                 }
             }
@@ -189,62 +118,8 @@ class BuildScaffolder(private val launcher: Launcher) {
                 instanceSetup { if (rootProject.aem.mvnBuild.available) dependsOn(":all:deploy") }
                 instanceResolve { dependsOn(":requireProps") }
                 instanceCreate { dependsOn(":requireProps") }
-                environmentUp { mustRunAfter(instanceAwait, instanceUp, instanceProvision, instanceSetup) }
-                environmentAwait { mustRunAfter(instanceAwait, instanceUp, instanceProvision, instanceSetup) }
             }
         """.trimIndent())
-    }
-
-    private fun saveEnvSrcFiles() {
-        launcher.workFileOnce("env/src/environment/docker-compose.yml.peb") {
-            println("Saving environment Docker compose file '$this'")
-            writeText("""
-                version: "3"
-                services:
-                  httpd:
-                    image: centos/httpd:latest
-                    command: ["tail", "-f", "--retry", "/usr/local/apache2/logs/error.log"]
-                    deploy:
-                      replicas: 1
-                    ports:
-                      - "80:80"
-                    volumes:
-                      - "{{ rootPath }}/dispatcher/src/conf.d:/etc/httpd/conf.d"
-                      - "{{ rootPath }}/dispatcher/src/conf.dispatcher.d:/etc/httpd/conf.dispatcher.d"
-                      - "{{ sourcePath }}/httpd:/etc/httpd.extra"
-                      - "{{ workPath }}/httpd/modules/mod_dispatcher.so:/etc/httpd/modules/mod_dispatcher.so"
-                      - "{{ workPath }}/httpd/logs:/etc/httpd/logs"
-                      {% if docker.runtime.safeVolumes %}
-                      - "{{ workPath }}/httpd/cache:/var/www/localhost/cache"
-                      - "{{ workPath }}/httpd/htdocs:/var/www/localhost/htdocs"
-                      {% endif %}
-                    {% if docker.runtime.hostInternalIpMissing %}
-                    extra_hosts:
-                      - "host.docker.internal:{{ docker.runtime.hostInternalIp }}"
-                    {% endif %}
-            """.trimIndent())
-        }
-
-        launcher.workFileOnce("env/src/environment/httpd/conf.d/variables/default.vars") {
-            println("Saving environment variables file '$this'")
-            writeText("""
-                Define DOCROOT /var/www/localhost/cache
-                Define AEM_HOST host.docker.internal
-                Define AEM_IP 10.0.*.*
-                Define AEM_PORT 4503
-
-                Define DISP_LOG_LEVEL Warn
-                Define REWRITE_LOG_LEVEL Warn
-                Define EXPIRATION_TIME A2592000
-            """.trimIndent())
-        }
-
-        launcher.workFileOnce("env/src/environment/httpd/conf.modules.d/02-dispatcher.conf") {
-            println("Saving environment HTTPD dispatcher config file '$this'")
-            writeText("""
-                LoadModule dispatcher_module modules/mod_dispatcher.so
-            """.trimIndent())
-        }
     }
 
     private fun saveSettings() = launcher.workFileOnce("settings.gradle.kts") {

--- a/launcher/src/main/kotlin/com/cognifide/gradle/aem/launcher/ForkScaffolder.kt
+++ b/launcher/src/main/kotlin/com/cognifide/gradle/aem/launcher/ForkScaffolder.kt
@@ -31,13 +31,6 @@ class ForkScaffolder(private val launcher: Launcher) {
 
             mvnBuild.args={{mvnBuildArgs}}
             mvnBuild.profiles={{mvnBuildProfiles}}
-            
-            dispatcher.tarUrl={{ dispatcherTarUri }}
-
-            # === Gradle Environment Plugin ===
-            {% if dockerSafeVolumes == 'true' %}
-            docker.desktop.safeVolumes=true
-            {% endif %}
 
             # === Gradle Common Plugin ===
             notifier.enabled=true
@@ -107,19 +100,6 @@ class ForkScaffolder(private val launcher: Launcher) {
                             label = "Open Automatically"
                             description = "Open web browser when instances are up."
                             select(OpenMode.values().map { it.name.toLowerCase() }, OpenMode.ALWAYS.name.toLowerCase())
-                        }
-                    }
-                    group("Dispatcher") {
-                        define("dispatcherTarUri") {
-                            label = "Tar Archive URI"
-                            description = "Typically file named 'dispatcher-apache2.4-linux-x86_64-*.tar.gz'"
-                            text("http://download.macromedia.com/dispatcher/download/dispatcher-apache2.4-linux-x86_64-4.3.3.tar.gz")
-                        }
-                        define("dockerSafeVolumes") {
-                            label = "Docker Safe Volumes"
-                            description = "Enables volumes for easily previewing e.g cache and logs (requires WSL2)"
-                            checkbox(false)
-                            dynamic("props")
                         }
                     }
                     group("Build") {

--- a/launcher/src/main/kotlin/com/cognifide/gradle/aem/launcher/MiscScaffolder.kt
+++ b/launcher/src/main/kotlin/com/cognifide/gradle/aem/launcher/MiscScaffolder.kt
@@ -12,7 +12,6 @@ class MiscScaffolder(private val launcher: Launcher) {
             .gradle/
             build/
             /gap.jar
-            dispatcher/src/conf.d/variables/default.vars
         """.trimIndent()
 
         if (!exists()) {


### PR DESCRIPTION
I figured that GEP should be entirely removed from the launcher in order to get rid of dispatcher, for which it is not feasible to maintain compatibility with the new AEM Project Archetype released by Adobe.