### PR TITLE
#786 Auto-lookup for files in directory

### DIFF
--- a/gradle/fork/gradle.user.properties.peb
+++ b/gradle/fork/gradle.user.properties.peb
@@ -2,5 +2,4 @@ systemProp.fileTransfer.user={{companyUser}}
 systemProp.fileTransfer.password={{companyPassword}}
 systemProp.fileTransfer.domain={{companyDomain}}
 
-systemProp.localInstance.quickstart.jarUrl={{ localInstanceQuickstartJarUri }}
-systemProp.localInstance.quickstart.licenseUrl={{ localInstanceQuickstartLicenseUri }}
+systemProp.localInstance.quickstart.dirUri={{ localInstanceQuickstartDirUri }}

--- a/launcher/src/main/kotlin/com/cognifide/gradle/aem/launcher/ForkScaffolder.kt
+++ b/launcher/src/main/kotlin/com/cognifide/gradle/aem/launcher/ForkScaffolder.kt
@@ -16,8 +16,7 @@ class ForkScaffolder(private val launcher: Launcher) {
             {% if packageDamAssetToggle == 'true' %}
             package.manager.workflowToggle=[dam_asset=false]
             {% endif %}
-            localInstance.quickstart.jarUrl={{ localInstanceQuickstartJarUri }}
-            localInstance.quickstart.licenseUrl={{ localInstanceQuickstartLicenseUri }}
+            localInstance.quickstart.dirUrl={{ localInstanceQuickstartDirUri }}
             localInstance.spUrl={{ localInstanceSpUri }}
             localInstance.coreComponentsUrl={{ localInstanceCoreComponentsUri }}
             localInstance.openMode={{ localInstanceOpenMode }}
@@ -81,13 +80,9 @@ class ForkScaffolder(private val launcher: Launcher) {
                             password("admin")
                             optional()
                         }
-                        define("localInstanceQuickstartJarUri") {
+                        define("localInstanceQuickstartDirUri") {
                             label = "Quickstart URI"
-                            description = "Typically file named 'cq-quickstart-*.jar' or 'aem-sdk-quickstart-*.jar'"
-                        }
-                        define("localInstanceQuickstartLicenseUri") {
-                            label = "Quickstart License URI"
-                            description = "Typically file named 'license.properties'"
+                            description = "Dir contains files named 'cq-quickstart-*.jar' or 'aem-sdk-quickstart-*.jar' and 'license.properties'"
                         }
                         define("localInstanceSpUri") {
                             label = "Service Pack URI"

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/QuickstartResolver.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/QuickstartResolver.kt
@@ -20,6 +20,13 @@ class QuickstartResolver(private val aem: AemExtension) {
      */
     val jarUrl = aem.obj.string {
         aem.prop.string("localInstance.quickstart.jarUrl")?.let { set(it) }
+        aem.prop.string("localInstance.quickstart.dirUrl")?.let {
+            set(
+                File(it).walk()
+                    .filter { ".*-quickstart-\\d\\.\\d\\.\\d+\\.jar".toRegex().matches(it.name) }
+                    .first().absolutePath
+            )
+        }
     }
 
     val jar: File? get() = jarUrl.orNull?.let { common.fileTransfer.downloadTo(it, downloadDir.get().asFile) }
@@ -29,6 +36,9 @@ class QuickstartResolver(private val aem: AemExtension) {
      */
     val licenseUrl = aem.obj.string {
         aem.prop.string("localInstance.quickstart.licenseUrl")?.let { set(it) }
+        aem.prop.string("localInstance.quickstart.dirUrl")?.let {
+            set(File(it).walk().filter { it.name.equals("license.properties") }.first().absolutePath)
+        }
     }
 
     val license: File? get() = licenseUrl.orNull?.let { common.fileTransfer.downloadTo(it, downloadDir.get().asFile) }


### PR DESCRIPTION
Don't need to specify files anymore, dir contained '*-quickstart-*.*.*.jar' and 'licence.properties' files is enough.
Compatible with earlier version ( 'localInstance.quickstart.jarUrl' and  'localInstance.quickstart.licenseUrl'