### PR TITLE
#885 Deprecation fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("java-gradle-plugin")
@@ -27,7 +27,7 @@ allprojects {
             withJavadocJar()
             withSourcesJar()
         }
-        tasks.withType<JavaCompile>().configureEach{
+        tasks.withType<JavaCompile>().configureEach {
             sourceCompatibility = JavaVersion.VERSION_1_8.toString()
             targetCompatibility = JavaVersion.VERSION_1_8.toString()
         }
@@ -45,6 +45,12 @@ allprojects {
     }
 }
 
+kotlin {
+    sourceSets.all {
+        languageSettings.optIn("kotlin.RequiresOptIn")
+    }
+}
+
 val functionalTestSourceSet = sourceSets.create("functionalTest")
 gradlePlugin.testSourceSets(functionalTestSourceSet)
 
@@ -56,8 +62,7 @@ dependencies {
     // Build environment
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.20.0-RC1")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.20.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
 
     implementation("com.cognifide.gradle:common-plugin:1.1.8")
@@ -65,13 +70,13 @@ dependencies {
     // External dependencies
     implementation("org.jsoup:jsoup:1.14.3")
     implementation("org.buildobjects:jproc:2.8.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")
     implementation("org.apache.commons:commons-lang3:3.12.0")
     implementation("commons-io:commons-io:2.11.0")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.1")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3")
     implementation("org.apache.httpcomponents:httpclient:4.5.13")
     implementation("biz.aQute.bnd:biz.aQute.bnd.gradle:5.3.0")
-    implementation("net.lingala.zip4j:zip4j:2.9.1")
+    implementation("net.lingala.zip4j:zip4j:2.10.0")
     implementation("org.osgi:org.osgi.core:6.0.0")
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation("io.jsonwebtoken:jjwt:0.9.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,14 +40,9 @@ allprojects {
         tasks.withType<KotlinCompile>().configureEach {
             kotlinOptions {
                 jvmTarget = JavaVersion.VERSION_1_8.toString()
+                freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
             }
         }
-    }
-}
-
-kotlin {
-    sourceSets.all {
-        languageSettings.optIn("kotlin.RequiresOptIn")
     }
 }
 
@@ -76,7 +71,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3")
     implementation("org.apache.httpcomponents:httpclient:4.5.13")
     implementation("biz.aQute.bnd:biz.aQute.bnd.gradle:5.3.0")
-    implementation("net.lingala.zip4j:zip4j:2.10.0")
+    implementation("net.lingala.zip4j:zip4j:2.9.1")
     implementation("org.osgi:org.osgi.core:6.0.0")
     implementation("javax.xml.bind:jaxb-api:2.3.1")
     implementation("io.jsonwebtoken:jjwt:0.9.1")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
+<<<<<<< HEAD
 version=16.0.0-alpha6
+=======
+version=16.0.0-alpha4
+>>>>>>> 45d1d791 (#885 Deprecation fix)
 release.useAutomaticVersion=true
-org.gradle.jvmargs=-Xmx1024m 
+org.gradle.jvmargs=-Xmx1024m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,3 @@
-<<<<<<< HEAD
 version=16.0.0-alpha6
-=======
-version=16.0.0-alpha4
->>>>>>> 45d1d791 (#885 Deprecation fix)
 release.useAutomaticVersion=true
-org.gradle.jvmargs=-Xmx1024m
+org.gradle.jvmargs=-Xmx1024m 

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/asset/AssetManager.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/asset/AssetManager.kt
@@ -19,7 +19,7 @@ class AssetManager(private val aem: AemExtension) {
         zip.parentFile.mkdirs()
         zip.outputStream().use { output ->
             this@AssetManager.javaClass.getResourceAsStream("/$ZIP_PATH").use {
-                    input ->
+                input ->
                 input.copyTo(output)
             }
         }

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/asset/AssetManager.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/asset/AssetManager.kt
@@ -19,7 +19,7 @@ class AssetManager(private val aem: AemExtension) {
         zip.parentFile.mkdirs()
         zip.outputStream().use { output ->
             this@AssetManager.javaClass.getResourceAsStream("/$ZIP_PATH").use {
-                input ->
+                    input ->
                 input.copyTo(output)
             }
         }

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/QuickstartResolver.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/QuickstartResolver.kt
@@ -35,7 +35,7 @@ class QuickstartResolver(private val manager: LocalInstanceManager) {
      * URI pointing to AEM self-extractable JAR containing 'crx-quickstart'.
      */
     val jarUrl = aem.obj.string {
-        convention(distUrl.map { it.takeIf { it.endsWith(".jar") } })
+        convention(distUrl.map { it.takeIf { it.endsWith(".jar") }.toString() })
         aem.prop.string("localInstance.quickstart.jarUrl")?.let { set(it) }
     }
 
@@ -54,7 +54,7 @@ class QuickstartResolver(private val manager: LocalInstanceManager) {
      * URI pointing to AEM SDK ZIP containing AEM instance JAR and Dispatcher Docker image.
      */
     val sdkUrl = aem.obj.string {
-        convention(distUrl.map { it.takeIf { it.endsWith(".zip") } })
+        convention(distUrl.map { it.takeIf { it.endsWith(".zip") }.toString() })
         aem.prop.string("localInstance.quickstart.sdkUrl")?.let { set(it) }
     }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/QuickstartResolver.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/QuickstartResolver.kt
@@ -34,8 +34,9 @@ class QuickstartResolver(private val manager: LocalInstanceManager) {
     /**
      * URI pointing to AEM self-extractable JAR containing 'crx-quickstart'.
      */
+    @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
     val jarUrl = aem.obj.string {
-        convention(distUrl.map { it.takeIf { it.endsWith(".jar") }.toString() })
+        convention(distUrl.map { it.takeIf { it.endsWith(".jar") } })
         aem.prop.string("localInstance.quickstart.jarUrl")?.let { set(it) }
     }
 
@@ -53,8 +54,9 @@ class QuickstartResolver(private val manager: LocalInstanceManager) {
     /**
      * URI pointing to AEM SDK ZIP containing AEM instance JAR and Dispatcher Docker image.
      */
+    @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
     val sdkUrl = aem.obj.string {
-        convention(distUrl.map { it.takeIf { it.endsWith(".zip") }.toString() })
+        convention(distUrl.map { it.takeIf { it.endsWith(".zip") } })
         aem.prop.string("localInstance.quickstart.sdkUrl")?.let { set(it) }
     }
 

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/tail/InstanceAnalyzer.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/tail/InstanceAnalyzer.kt
@@ -31,7 +31,7 @@ class InstanceAnalyzer(
         }
         GlobalScope.launch {
             while (isActive) {
-                val log = incidentChannel.poll()
+                val log = incidentChannel.tryReceive().getOrNull()
                 if (log != null) {
                     incidentCannonade.add(log)
                 }

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/tail/LogNotifier.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/tail/LogNotifier.kt
@@ -3,7 +3,6 @@ package com.cognifide.gradle.aem.common.instance.tail
 import com.cognifide.gradle.aem.common.instance.tail.io.LogFiles
 import com.cognifide.gradle.common.notifier.NotifierFacade
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consumeEach
@@ -12,7 +11,7 @@ import org.gradle.api.logging.LogLevel
 import java.awt.Desktop
 import java.net.URI
 
-@OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
+@OptIn(DelicateCoroutinesApi::class)
 class LogNotifier(
     private val notificationChannel: ReceiveChannel<LogChunk>,
     private val notifier: NotifierFacade,

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/mvn/MvnGav.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/mvn/MvnGav.kt
@@ -1,6 +1,7 @@
 package com.cognifide.gradle.aem.common.mvn
 
 import groovy.util.*
+import groovy.xml.XmlParser
 import java.io.File
 
 data class MvnGav(


### PR DESCRIPTION
What about: 

```
> Task :generateMetadataFileForPluginMavenPublication
Execution optimizations have been disabled for task ':generateMetadataFileForPluginMavenPublication' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: 'C:\projects\gradle-aem-plugin\build\libs\aem-plugin-16.0.0-alpha4-javadoc.jar'. Reason: Task ':generateMetadataFileForPluginMavenPublication' uses this output of task ':publishPluginJavaDocsJar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: 'C:\projects\gradle-aem-plugin\build\libs\aem-plugin-16.0.0-alpha4-sources.jar'. Reason: Task ':generateMetadataFileForPluginMavenPublication' uses this output of task ':publishPluginJar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
Gradle detected a problem with the following location: 'C:\projects\gradle-aem-plugin\build\libs\aem-plugin-16.0.0-alpha4-javadoc.jar'. Reason: Task ':generateMetadataFileForPluginMavenPublication' uses this output of task ':publishPluginJavaDocsJar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.1/userguide/validation_problems.html#implicit_dependency for more details about this problem. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. Execution optimizations are disabled to ensure correctness. See https://docs.gradle.org/7.4.1/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Gradle detected a problem with the following location: 'C:\projects\gradle-aem-plugin\build\libs\aem-plugin-16.0.0-alpha4-sources.jar'. Reason: Task ':generateMetadataFileForPluginMavenPublication' uses this output of task ':publishPluginJar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.1/userguide/validation_problems.html#implicit_dependency for more details about this problem. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. Execution optimizations are disabled to ensure correctness. See https://docs.gradle.org/7.4.1/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
```

? It looks like it depends form `maven-publish`.