### PR TITLE
SDK version updating

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,6 @@ defaultTasks(":publishToMavenLocal", ":launcher:publishToMavenLocal")
 
 allprojects {
     repositories {
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }
@@ -61,7 +60,7 @@ dependencies {
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.20.0-RC1")
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
 
-    implementation("com.cognifide.gradle:common-plugin:1.1.9")
+    implementation("com.cognifide.gradle:common-plugin:1.1.8")
 
     // External dependencies
     implementation("org.jsoup:jsoup:1.14.3")

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/QuickstartResolver.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/QuickstartResolver.kt
@@ -67,7 +67,7 @@ class QuickstartResolver(private val manager: LocalInstanceManager) {
 
     val sdkWorkDir: File get() = sdkDir.get().asFile
 
-    private val sdkVersionFile: File get() = sdkWorkDir.parentFile.resolve("sdk.txt")
+    private val sdkVersionFile: File get() = sdkWorkDir.parentFile.resolve("sdk.md5")
 
     val sdkJar: File? get() = sdk
         ?.also { unpackSdkZip(it) }

--- a/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/QuickstartResolver.kt
+++ b/src/main/kotlin/com/cognifide/gradle/aem/common/instance/local/QuickstartResolver.kt
@@ -80,7 +80,6 @@ class QuickstartResolver(private val manager: LocalInstanceManager) {
         ?.also { unpackSdkDispatcher() }
         ?.let { sdkDispatcherDir?.resolve("lib/dispatcher-publish-${OSUtil.archOfHost()}.tar.gz")?.takeIf { it.exists() } }
 
-
     private fun unpackSdkZip(zip: File) {
         val versionCurrent = Formats.toChecksum(zip)
         val versionPrevious = sdkVersionFile.takeIf { it.exists() }?.readText()?.trim()
@@ -107,7 +106,7 @@ class QuickstartResolver(private val manager: LocalInstanceManager) {
         sdkWorkDir.listFiles { _, name -> Patterns.wildcard(name, "*-dispatcher-*-unix.sh") }
             ?.firstOrNull()
             ?.let { script ->
-                sdkDispatcherDir?.takeIf { !it.exists() }?.let {dir ->
+                sdkDispatcherDir?.takeIf { !it.exists() }?.let { dir ->
                     common.progress {
                         step = "Unpacking AEM SDK Dispatcher Tools: ${script.name} (${Formats.fileSize(script)})"
                         try {


### PR DESCRIPTION
if sb will update sdk zip then GAP will erase previously unpacked SDK and unpack again AEM SDK JAR automatically.

`docker load` is run each time `envUp` task is called and during this task it is check docker-compose.yml file. if loaded image name and version changes then `envUp` task will destroy env and create it again so it should work as a whole.

